### PR TITLE
open2ch.net で更新を検出できない対策

### DIFF
--- a/modules/utils.jsm
+++ b/modules/utils.jsm
@@ -562,6 +562,7 @@ HTTPRequest.prototype = {
 		this._request.addEventListener("error", this, false);
 		this._request.QueryInterface(Ci.nsIXMLHttpRequest);
 		this._request.open("GET", aURL, true);
+		this._request.channel.loadFlags |= Ci.nsIRequest.LOAD_BYPASS_CACHE;
 		this._request.setRequestHeader("User-Agent", FoxAge2chUtils.userAgent);
 		this._request.channel.contentCharset = aURL.indexOf("jbbs.shitaraba.net") >= 0 ? "EUC-JP" : "Shift_JIS";
 		this._request.send(null);


### PR DESCRIPTION
お初にお目にかかります。いつも FoxAge2ch をはじめ、 gomitaさんのアドオンを利用させて頂いております。
この変更は open2ch.net で更新を検出できない問題がありまして、その対策としてリクエストに LOAD_BYPASS_CACHE フラグを設定するというものです。採用していただきたくお願いいたします。

また、ついでと言ってはなんですが、FoxAge2ch の AMO公開のご予定はございますでしょうか。
すでに Firefox 40 において、無署名アドオンに警告が出るようになりました。
chaika 利用者の間では FoxAge2ch が使えなくなるのではという不安がございます。
よろしくご検討お願いいたします。