### PR TITLE
bbspink.com で移転先が検出できないサーバが現れたことへの対策

### DIFF
--- a/chrome/content/foxage2ch/transfer.js
+++ b/chrome/content/foxage2ch/transfer.js
@@ -35,7 +35,7 @@ var TransferWizard = {
 			this.owner.wizard.getButton("cancel").disabled = false;
 		};
 		var loadCallback = function(aResponseText) {
-			if (aResponseText.indexOf("<title>2chbbs..</title>"   ) < 0 || 
+			if (!/<title>(?:2chbbs|bbspink)\.\.<\/title>/.test(aResponseText) || 
 			    aResponseText.indexOf("Change your bookmark ASAP.") < 0 || 
 			    !/window\.location\.href=\"([^\"]+)\"/.test(aResponseText)) {
 				this._errorCallback(this.owner.bundle.getString("DETECT_FAILURE"));


### PR DESCRIPTION
2016年6月頃から移転通知htmlのtitleが `<title>bbspink..</title>` となっているサーバが現れたため、この仕様変更に対応するものです。

ネタ元
http://potato.2ch.net/test/read.cgi/software/1333972010/617-618