### PR TITLE
スレッド検索ウィザードの「元スレを削除」の状態を記憶する

### DIFF
--- a/chrome/content/foxage2ch/findThread.xul
+++ b/chrome/content/foxage2ch/findThread.xul
@@ -85,7 +85,7 @@
 				</rule>
 			</template>
 		</tree>
-		<checkbox id="resultCheckbox" orglabel="&resultCheckbox;: " />
+		<checkbox id="resultCheckbox" orglabel="&resultCheckbox;: " persist="checked" />
 	</wizardpage>
 
 </wizard>


### PR DESCRIPTION
これは不具合修正ではなくちょっとした改良提案です。採用するかどうかはgomitaさんの判断にお任せします。

2chでのユーザーの声を聞いてみると、次スレ検索の使用頻度が多いので「元スレを削除」のチェックボックスがＯＮの状態でダイアログを開ければ便利という声が案外多いような気がしました。
そこで、「元スレを削除」の状態を persist で記憶するようにしてみたものです。

削除動作が既定値になってしまうのはUI的にちょっと危険でもあるのですが、この場合はうっかり削除してしまっても履歴などが残っていれば再登録が可能ですので、デメリットよりもメリットの方が大きいように思います。

ネタ元
http://potato.2ch.net/test/read.cgi/software/1333972010/623-629