### PR TITLE
chaika-1.8.0 にて仕様変更された板URLを認識させる

### DIFF
--- a/chrome/content/foxage2ch/foxage2ch.js
+++ b/chrome/content/foxage2ch/foxage2ch.js
@@ -547,8 +547,9 @@ var FoxAge2chUI = {
 			if (!win)
 				return;
 			var scheme = win.gBrowser.currentURI.scheme;
-			var val = scheme == "chrome" || scheme == "about" ? "" : 
-			          FoxAge2chUtils.unwrapURL(win.gBrowser.currentURI.spec);
+			// chaika-1.8.0 以降の板URL chrome://chaika/content/board/page.xul?url=[URL] を認識させる
+			var val = scheme == "chrome" && win.gBrowser.currentURI.host != "chaika" || scheme == "about"
+			        ? "" : FoxAge2chUtils.unwrapURL(win.gBrowser.currentURI.spec);
 			var ret = { value: val };
 			if (!FoxAge2chUtils.prompt.prompt(window, "FoxAge2ch", msg, ret, null, {}))
 				return;


### PR DESCRIPTION
chaika-1.8.0 以降においては、e10s の制約から、板(スレッド一覧)URLが `chaika://board/[URL]` から `chrome://chaika/content/board/page.xul?url=[URL]` へと変更されています。

chaika-1.8.0 以降でスレッド一覧を開いている状態で「スレッド／板を追加」ボタンを押したときに、その板URLを認識して追加ダイアログの初期値にするものです。

コードの変更点は必要最小限のみであまりエレガントではありませんが、動作は確認済みですし、これでも特に問題は起こらないと思います。