### PR TITLE
Firefox 51 以降でブラウザタブの Drag&Drop を認識しなくなったことへの対策

### DIFF
--- a/chrome/content/foxage2ch/foxage2ch.js
+++ b/chrome/content/foxage2ch/foxage2ch.js
@@ -398,7 +398,7 @@ var FoxAge2chUI = {
 			case "dragover": 
 				// URL（リンクやfavicon）またはブラウザタブのドロップを許可
 				if (dt.types.contains("text/x-moz-url") || 
-				    dt.types.contains("application/x-moz-tabbrowser-tab"))
+				    dt.types.contains("text/x-moz-text-internal"))
 					event.preventDefault();
 				break;
 			case "drop": 
@@ -412,7 +412,7 @@ var FoxAge2chUI = {
 					var url = dt.getData("text/x-moz-url").split("\n")[0];
 					this.addURL(url);
 				}
-				else if (dt.types.contains("application/x-moz-tabbrowser-tab")) {
+				else if (dt.types.contains("text/x-moz-text-internal")) {
 					// ブラウザタブのドロップ時、板やスレを追加
 					var url = dt.getData("text/x-moz-text-internal");
 					this.addURL(url);


### PR DESCRIPTION
Firefox 50 にて Drag&Drop データ受け渡し用の新API DataTransfer.items が追加され、さらに Firefox 51 以降では旧APIである DataTransfer.types に application/x-moz-tabbrowser-tab が含まれなくなりました。

Firefox のソースコードを見ると、データの種類 kind が string, file のもののみ DataTransfer.types に現れるようになっていて、HTMLの規定に厳密に従うという意味では意図した動作のようにも思えるし、双方のAPIで見える内容が異なるという点ではバグのようにも思えるし、自分にはよく解らなかったです。

とりあえず現時点の Nightly でも同じ動作なので、修正コードを書いてみました。エレガントとは言い難いコードですし、コーディングスタイルが違っていたらごめんなさい。
タブ以外のD&Dは問題なく認識できるので、元どおりに直す必要性は低いかもしれませんが、その辺の判断はお任せいたします。