### PR TITLE
bbspink.com のフォルダアイコンが表示されなくなったことへの対策

### DIFF
--- a/chrome/skin/classic/foxage2ch/foxage2ch.css
+++ b/chrome/skin/classic/foxage2ch/foxage2ch.css
@@ -85,7 +85,7 @@ treechildren::-moz-tree-image(leaf, thread, primary, datout) {
 
 treechildren::-moz-tree-image(container, pink) {
 	-moz-image-region: auto !important;
-	list-style-image: url("http://www.bbspink.com/favicon.ico") !important;
+	list-style-image: url("http://deleter.bbspink.com/favicon.ico") !important;
 	width: 16px; height: 16px;
 }
 


### PR DESCRIPTION
2017年3月初め頃に bbspink.com でページデザイン変更がありまして、`http://www.bbspink.com/favicon.ico` が 404 Not Found になりました。
Firefox のキャッシュに残っている限り問題なく表示されますが、キャッシュから消えてしまうとフォルダアイコンに何も表示されなくなってしまいます。

何か他に使えそうなアイコンが無いか探してみると：
板のあるサーバの favicon は 2ch.net と全く同じ②アイコン http://mercury.bbspink.com/favicon.ico
各板のスレ一覧で表示されるパンティ型のsvgアイコン http://mercury.bbspink.com/_gichin/images/BBSPINK%20Icon-01.svg
BBSPINK Official Wiki で表示される旧faviconと同じアイコン http://deleter.bbspink.com/favicon.ico

一応、旧faviconと同じものが表示されるようにしてみましたが、2ch.net と同じくデフォルトのフォルダアイコンでも良いかもしれません。どうするかはお任せします。
