### PR TITLE
2ch.net のSSL化への対応について

### DIFF
--- a/chrome/content/foxage2ch/transfer.js
+++ b/chrome/content/foxage2ch/transfer.js
@@ -77,7 +77,7 @@ var TransferWizard = {
 		var oldHost = this.boardItem.id.substr(0, this.boardItem.id.indexOf("/"));
 		// http://pc11.2ch.net/software/ → pc11.2ch.net
 		// //hawk.2ch.net/livejupiter/ のような相対URLの場合もある(2017/3/24)
-		if (!/^(?:http:)?\/\/([^\/]+)\//.test(aNewURL))
+		if (!/^(?:https?:)?\/\/([^\/]+)\//.test(aNewURL))
 			throw Cr.NS_ERROR_UNEXPECTED;
 		var newHost = RegExp.$1;
 		this.trace(this.bundle.getString("DETECT_SUCCESS") + ": " + oldHost + " \u2192 " + newHost);

--- a/modules/utils.jsm
+++ b/modules/utils.jsm
@@ -157,8 +157,7 @@ var FoxAge2chUtils = {
 	// 「http://...http://」のようにビューアやWebサービスによってラップされたURLについて、
 	// 最後のhttp://以降をURLとみなして返す
 	unwrapURL: function F2U_unwrapURL(aURL) {
-		var pos = aURL.lastIndexOf("http://");
-		return pos >= 0 ? aURL.substr(pos) : aURL;
+		return /^.*(https?:\/\/.+?)$/.test(aURL) ? RegExp.$1 : aURL;
 	},
 
 	// 登録可能なURLをパースして、[板のアイテムID, スレッドのアイテムID] の配列へ変換する
@@ -168,9 +167,9 @@ var FoxAge2chUtils = {
 	parseFromURL: function F2U_parseFromURL(aURL) {
 		// unwrapURLは呼び出しもとのFoxAge2chUI.addURL側で実施する
 		// aURL = this.unwrapURL(aURL);
-		if (aURL.indexOf("http://") != 0)
+		if (!/^https?:\/\//.test(aURL))
 			throw Cr.NS_ERROR_MALFORMED_URI;
-		aURL = aURL.substr("http://".length);
+		aURL = RegExp.rightContext;
 		if (/\/test\/read\.(?:cgi|so|html)\/(\w+)\/(\d+)/.test(aURL))
 			// ２ちゃんねるスレッド
 			// http://pc7.2ch.net/test/read.cgi/software/1234567890/l50


### PR DESCRIPTION
こんにちは。便利に利用させていただいています。不具合への対応いつもありがとうございます。

2ch.net ですが、どうやら本当に常時SSL化しようとしているようで、新サーバの移転先URLを https: のURLで告知してくる場合も出てきました（http://potato.2ch.net → https://egg.2ch.net など）。

一方、現バージョンの FoxAge2ch は、移転ウィザードや新規登録などで https: のURLは全く受け付けず全てエラーになってしまいます。とりあえず現時点ではそれらの新サーバも http: でアクセスすることは可能なので、暫定的に https: のURLを http: に解釈して受け付けるようにしてみました。

本来ならば、https: で登録したアイテムは https: のURLで開けるように区別して登録されるようにすべきでしょうけど、そうなるとデータ構造も含め広範囲の変更を要するので、現時点で不便がなければいい程度に必要最小限の変更だけにしています。