### PR TITLE
2ch.netでサーバ移転を検知できない場合が出てきたことへの対策

### DIFF
--- a/modules/utils.jsm
+++ b/modules/utils.jsm
@@ -601,18 +601,13 @@ HTTPRequest.prototype = {
 	handleEvent: function HR_handleEvent(aEvent) {
 		try {
 			var validateURL = function(aChannel) {
-				var errorURLs = [
-					"http://www2.2ch.net/nogood.html", 
-					"http://www2.2ch.net/live.html", 
-					"http://server.maido3.com/"
-				];
 				// #debug-begin
-				if (errorURLs.indexOf(aChannel.URI.spec) >= 0) {
+				if (aChannel.originalURI.spec != aChannel.URI.spec) {
 					var msg = aChannel.originalURI.spec + " -> " + aChannel.URI.spec;
 					FoxAge2chUtils.reportError("Redirected:\n" + msg);
 				}
 				// #debug-end
-				return errorURLs.indexOf(aChannel.URI.spec) >= 0;
+				return aChannel.originalURI.spec != aChannel.URI.spec;
 			};
 			// 一部の鯖（uni.2ch.netなど）で、移転済みにも関わらずsubject.txtがリダイレクトされず
 			// HTTPステータス200で返ってくるため、その中身まで見ないと移転済みかを判別できない。


### PR DESCRIPTION
2017年5月中旬頃からですが、「人大杉」へのリダイレクトではなく板移転先の subject.txt へのリダイレクトを返してくるケースが出てきました。

この場合、板移転先の subject.txt を自動的に読みに行ってくれるので、スレッドの更新チェックは正常に行われますが、板が移転したことを検知できていませんので、アイテムを開くと移転前の URL が開かれてしまいます。

validateURL の判定条件ですが、上記の新たな条件を単純に追加すると
`aChannel.originalURI.spec != aChannel.URI.spec && (aChannel.URI.fileName == "subject.txt" || errorURLs.indexOf(aChannel.URI.spec) >= 0)`
というような感じになるんでしょうけど、後半の条件は冗長に見えますし、リダイレクトが発生した時点で板移転と判定している専ブラが多いようなので、それに倣って判定条件を簡略化しました。
